### PR TITLE
Fix TODO in python memory checker

### DIFF
--- a/tensorflow/python/framework/python_memory_checker.py
+++ b/tensorflow/python/framework/python_memory_checker.py
@@ -82,8 +82,22 @@ class _PythonMemoryChecker(object):
 
   @trace.trace_wrapper
   def report(self):
-    # TODO(kkb): Implement.
-    pass
+    """Log object allocation differences between snapshots."""
+
+    if len(self._snapshots) < 2:
+      logging.info('Insufficient snapshots for memory report.')
+      return {}
+
+    diff_map = collections.OrderedDict()
+    for i in range(len(self._snapshots) - 1):
+      diff = self._snapshot_diff(i, i + 1)
+      if diff:
+        diff_map[f'{i}->{i + 1}'] = diff
+
+    for key, counter in diff_map.items():
+      logging.info('Snapshot diff %s: %s', key, counter.most_common(5))
+
+    return diff_map
 
   @trace.trace_wrapper
   def assert_no_leak_if_all_possibly_except_one(self):


### PR DESCRIPTION
## Summary
- implement a simple report() helper in `python_memory_checker`

## Testing
- `python -m py_compile tensorflow/python/framework/python_memory_checker.py`
- `pytest tensorflow/examples/adding_an_op/zero_out_1_test.py -q` *(fails: Could not import tensorflow from source tree)*
- `pytest tensorflow/tensorflow/python/framework/memory_checker_test.py::MemoryCheckerTest::testNoLeakEmpty -q` *(fails: Could not import tensorflow from source tree)*
