### PR TITLE
Fix Adam update and cleanup header

### DIFF
--- a/tensorflow/core/kernels/poisson-loss.h
+++ b/tensorflow/core/kernels/poisson-loss.h
@@ -106,4 +106,4 @@ class PoissonLossUpdater : public DualLossUpdater {
 
 }  // namespace tensorflow
 
-#endif  // TENSORFLOW_CORE_KERNELS_LOGISTIC_LOSS_H_
+#endif  // TENSORFLOW_CORE_KERNELS_POISSON_LOSS_H_

--- a/tensorflow/python/keras/optimizer_v2/adam.py
+++ b/tensorflow/python/keras/optimizer_v2/adam.py
@@ -438,7 +438,7 @@ class NonFusedAdam(optimizer_v2.OptimizerV2):
       vhat.assign(math_ops.maximum(vhat, v))
       v = vhat
     var.assign_sub(
-        (m * alpha) / (math_ops.sqrt(v) - coefficients['epsilon']))
+        (m * alpha) / (math_ops.sqrt(v) + coefficients['epsilon']))
 
   @def_function.function(jit_compile=True)
   def _resource_apply_sparse(self, grad, var, indices, apply_state=None):

--- a/tensorflow/python/keras/optimizer_v2/adam_test.py
+++ b/tensorflow/python/keras/optimizer_v2/adam_test.py
@@ -1,0 +1,27 @@
+import os
+from absl.testing import parameterized
+
+from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import test_util
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import test
+from tensorflow.python.keras.optimizer_v2 import adam
+
+
+class AdamDenseUpdateTest(test.TestCase, parameterized.TestCase):
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_single_dense_update(self):
+    var = variables.Variable([1.0], dtype=dtypes.float32)
+    grad = constant_op.constant([1.0], dtype=dtypes.float32)
+    opt = adam.NonFusedAdam(learning_rate=0.1, beta_1=0.0, beta_2=0.0, epsilon=0.1)
+    self.evaluate(variables.global_variables_initializer())
+    opt.apply_gradients([(grad, var)])
+    expected = 1.0 - 0.1 / (1.0 + 0.1)
+    self.assertAllClose(self.evaluate(var)[0], expected)
+
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
## Summary
- fix epsilon sign in NonFusedAdam dense update
- correct closing comment in Poisson loss header
- add regression test for Adam dense update

## Testing
- `python tensorflow/python/keras/optimizer_v2/adam_test.py` *(fails: ModuleNotFoundError: No module named 'absl')*
